### PR TITLE
Bump version to 2.1.0 for cache-performance

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-utils", version: "2.0.1", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-utils", version: "2.1.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/org/savantbuild/net/NetTools.java
+++ b/src/main/java/org/savantbuild/net/NetTools.java
@@ -111,10 +111,7 @@ public class NetTools {
     return writeToTempFile(uc.getInputStream(), md5);
   }
 
-  private static Path fetchViaHttp(URI uri,
-                                   String username,
-                                   String password,
-                                   MD5 md5) throws IOException {
+  private static Path fetchViaHttp(URI uri, String username, String password, MD5 md5) throws IOException {
     var requestBuilder = HttpRequest.newBuilder()
                                     .uri(uri)
                                     .GET()


### PR DESCRIPTION
## Summary
- Bump project version to 2.1.0 to align all core Savant projects for the cache-performance feature
- Reformat `NetTools.fetchViaHttp` method signature to single line

## Test plan
- [ ] Verify `sb int` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)